### PR TITLE
[염정운] 대시보드 데이터 바인딩

### DIFF
--- a/modules/common/user/user_utils.py
+++ b/modules/common/user/user_utils.py
@@ -61,24 +61,28 @@ def get_canceled_users(info_db_no: int, origin_table: str):
     return canceled_users
 
 # 구독 모델 판별
+from typing import List, Dict, Tuple
+import pandas as pd
+
 def determine_subscription_model(
-        users: pd.DataFrame,
+    users: pd.DataFrame,
 ) -> Tuple[List[Dict], List[Dict], List[Dict]]:
 
     basic: List[Dict] = []
+    standard: List[Dict] = []
     premium: List[Dict] = []
-    ultimate: List[Dict] = []
 
     for _, user in users.iterrows():
-        sub_type = (user.get('prev_subscription') or '').lower()
+        sub_type = (user.get('subscription_type') or '').strip().lower()
+
         if sub_type == 'basic':
             basic.append(user.to_dict())
+        elif sub_type == 'standard':
+            standard.append(user.to_dict())
         elif sub_type == 'premium':
             premium.append(user.to_dict())
-        elif sub_type == 'ultimate':
-            ultimate.append(user.to_dict())
 
-    return basic, premium, ultimate
+    return basic, standard, premium
 
 def calculate_percentages(*subscription_groups: List) -> Union[tuple[float, float, float], tuple[float, ...]]:
     """구독 모델 비율 계산"""

--- a/modules/devide/subscription.py
+++ b/modules/devide/subscription.py
@@ -35,7 +35,9 @@ def get_subscription_data(
             month_start = month_start.replace(tzinfo=None)
             month_end = month_end.replace(tzinfo=None)
             filtered = _filter_user_data(df, users_type, month_start, month_end, one_year_ago)
+
             basic, premium, ultimate = get_subscription_breakdown(filtered)
+
             subscription_data[month_start.strftime('%Y-%m')] = calculate_percentages(basic, premium, ultimate)
         return dict(subscription_data)
     else:

--- a/routes/dash_board_routes.py
+++ b/routes/dash_board_routes.py
@@ -67,7 +67,11 @@ def dashboard_index():
     writer.writerow([])  # 빈 줄로 구분
     writer.writerow(['month', 'subscribers', 'rate(%)'])
     for _, row in increase_decrease_df.iterrows():
-        writer.writerow(row)
+        writer.writerow([
+            row['month'],
+            round(row.get('cumulative', 0), 2),  # 누적 가입자 수 (있다면)
+            round(row['increase_decrease_per'], 2)  # 증감률 소수점 둘째 자리
+        ])
 
     # 6. 응답 반환
     response = make_response(csv_buffer.getvalue())


### PR DESCRIPTION
python ML 서버에서 netflix.csv를 기준으로 했을 때 수정 해야 할 점이 있어서 해당 부분을 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 구독 유형 분류에서 'ultimate' 대신 'standard' 구독 유형이 추가되어 사용자 분류가 개선되었습니다.
	- 구독 취소율 계산 방식이 최근 30일 내 취소된 사용자 기준으로 정밀하게 변경되었습니다.
- **스타일**
	- 월별 구독 데이터 처리 시 코드 가독성을 위한 공백이 추가되었습니다.
- **기타**
	- 대시보드용 CSV 내보내기에서 특정 컬럼만 소수점 두 자리로 포맷하여 저장하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->